### PR TITLE
don't use a path in NVIM_APPNAME

### DIFF
--- a/dotfyle
+++ b/dotfyle
@@ -102,7 +102,13 @@ run() {
   fi
   if [ -n "$appname" ]; then
     echo "$appname" > "$HOME/.config/$dir_name/.last_used"
-    NVIM_APPNAME="$dir_name/$appname" exec nvim
+    apppath=$(dirname "$appname")
+    NVIM_APPNAME=$(basename "$appname") \
+    XDG_CONFIG_HOME="$HOME/.config/$dir_name/$apppath" \
+    XDG_DATA_HOME="$HOME/.local/share/$dir_name/$apppath" \
+    XDG_STATE_HOME="$HOME/.local/state/$dir_name/$apppath" \
+    XDG_CACHE_HOME="$HOME/.cache/$dir_name/$apppath" \
+    exec nvim
   fi
 }
 


### PR DESCRIPTION
This will let `NVIM_APPNAME` stay just a name, meaning it will work with nightly ([relevant issue](https://github.com/neovim/neovim/issues/24966))

It may however break the universe, I don't yet know. I usually try to not touch XDG directories, but I think using a path in NVIM_APPNAME would theoretically have the same issues and that's why they don't want to support it.

Right now using a path works for stable, and the dev branch should<sup>TM</sup> work for everything.

Installation:
```sh
curl -o ~/.local/bin/dotfyle https://raw.githubusercontent.com/RoryNesbitt/dotfyle-cli/dev/dotfyle
chmod +x ~/.local/bin/dotfyle
```